### PR TITLE
Fix Buffer usage

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -118,7 +118,7 @@ const getPdf = async (event) => {
 		.upload({
 			Bucket: process.env.S3_BUCKET,
 			Key: `${Date.now()}.pdf`,
-			Body: new Buffer.from(data, "base64"),
+                        Body: Buffer.from(data, "base64"),
 			ACL: 'public-read',
 		})
 		.promise();


### PR DESCRIPTION
## Summary
- remove deprecated `new` keyword usage for `Buffer.from`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f6360fc24832cb30d052a1cc5b418